### PR TITLE
Fix compile errors

### DIFF
--- a/src/geometry.cpp
+++ b/src/geometry.cpp
@@ -30,11 +30,6 @@
 #ifndef GEOMETRY_CPP
 #define GEOMETRY_CPP
 
-//Function absolute value
-double abs(const double &x)
-{
-  return max(x,-x);
-}
 
 //////////////////////////////////////////////
 //  Class Bbox                              //


### PR DESCRIPTION
On some compilers, the definition of "abs" in "geometry.cpp" conflicts
with "abs" included in <cmath.h>. This causes an error on some
compilers.

The code compiles without and the abs function works as intended.

The change should be propagated on other branches.

Fixes #2 